### PR TITLE
Add cubemap support & add ktx basic writer implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ktx"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Alex Butler <alexheretic@gmail.com>"]
 edition = "2018"
 description = "KTX texture storage format parsing"

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,7 +1,8 @@
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
-pub(crate) const KTX_IDENTIFIER: [u8; 12] =
-    [0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A];
+pub(crate) const KTX_IDENTIFIER: [u8; 12] = [
+    0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A,
+];
 
 /// KTX texture storage format parameters.
 ///
@@ -131,6 +132,41 @@ impl KtxHeader {
             mipmap_levels: vals[10],
             bytes_of_key_value_data: vals[11],
         }
+    }
+
+    pub fn write(&self, first_64_bytes: &mut [u8]) {
+        debug_assert!(first_64_bytes.len() >= 64);
+
+        let mut vals: [u32; 13] = <_>::default();
+        vals[0] = if self.big_endian { 4 } else { 0 };
+        vals[1] = self.gl_type;
+        vals[2] = self.gl_type_size;
+        vals[3] = self.gl_format;
+        vals[4] = self.gl_internal_format;
+        vals[5] = self.gl_base_internal_format;
+        vals[6] = self.pixel_width;
+        vals[7] = self.pixel_height;
+        vals[8] = self.pixel_depth;
+        vals[9] = self.array_elements;
+        vals[10] = self.faces;
+        vals[11] = self.mipmap_levels;
+        vals[12] = self.bytes_of_key_value_data;
+
+        (&mut first_64_bytes[0..KTX_IDENTIFIER.len()]).copy_from_slice(&KTX_IDENTIFIER);
+
+        if self.big_endian {
+            BigEndian::write_u32_into(
+                &vals,
+                &mut first_64_bytes[KTX_IDENTIFIER.len()
+                    ..KTX_IDENTIFIER.len() + (vals.len() * std::mem::size_of::<u32>())],
+            )
+        } else {
+            LittleEndian::write_u32_into(
+                &vals,
+                &mut first_64_bytes[KTX_IDENTIFIER.len()
+                    ..KTX_IDENTIFIER.len() + (vals.len() * std::mem::size_of::<u32>())],
+            );
+        };
     }
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -138,7 +138,7 @@ impl KtxHeader {
         debug_assert!(first_64_bytes.len() >= 64);
 
         let mut vals: [u32; 13] = <_>::default();
-        vals[0] = if self.big_endian { 4 } else { 0 };
+        vals[0] = 0x04030201;
         vals[1] = self.gl_type;
         vals[2] = self.gl_type_size;
         vals[3] = self.gl_format;

--- a/src/header.rs
+++ b/src/header.rs
@@ -87,19 +87,19 @@ pub trait KtxInfo {
 /// KTX texture storage format header. Provides [`KtxInfo`](../header/trait.KtxInfo.html).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct KtxHeader {
-    big_endian: bool,
-    gl_type: u32,
-    gl_type_size: u32,
-    gl_format: u32,
-    gl_internal_format: u32,
-    gl_base_internal_format: u32,
-    pixel_width: u32,
-    pixel_height: u32,
-    pixel_depth: u32,
-    array_elements: u32,
-    faces: u32,
-    mipmap_levels: u32,
-    bytes_of_key_value_data: u32,
+    pub big_endian: bool,
+    pub gl_type: u32,
+    pub gl_type_size: u32,
+    pub gl_format: u32,
+    pub gl_internal_format: u32,
+    pub gl_base_internal_format: u32,
+    pub pixel_width: u32,
+    pub pixel_height: u32,
+    pub pixel_depth: u32,
+    pub array_elements: u32,
+    pub faces: u32,
+    pub mipmap_levels: u32,
+    pub bytes_of_key_value_data: u32,
 }
 
 impl KtxHeader {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,13 @@
 
 pub mod header;
 pub mod slice;
+
 #[cfg(feature = "std")]
 pub mod read;
 
-pub use slice::Ktx;
+pub mod write;
+
 pub use header::KtxInfo;
 #[cfg(feature = "std")]
 pub use read::KtxDecoder as Decoder;
+pub use slice::Ktx;

--- a/src/read.rs
+++ b/src/read.rs
@@ -35,7 +35,9 @@ impl<R> AsRef<KtxHeader> for KtxDecoder<R> {
 
 impl<R> fmt::Debug for KtxDecoder<R> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("KtxDecoder").field("header", &self.header).finish()
+        fmt.debug_struct("KtxDecoder")
+            .field("header", &self.header)
+            .finish()
     }
 }
 
@@ -52,7 +54,11 @@ impl<R: io::Read> KtxDecoder<R> {
     /// Consumes the `KtxDecoder` to returns an iterator reading texture levels starting at level 0.
     #[inline]
     pub fn read_textures(self) -> Textures<R> {
-        Textures { header: self.header, data: self.data, next_level: 0 }
+        Textures {
+            header: self.header,
+            data: self.data,
+            next_level: 0,
+        }
     }
 
     /// Returns `KtxHeader`. Useful if this info is desired after consuming the `KtxDecoder`.
@@ -108,8 +114,19 @@ impl<R: io::Read> Iterator for Textures<R> {
                 }
             };
 
+            let level_len = if self.header.array_elements() == 0 && self.header.faces() == 6 {
+                6 * level_len
+            } else {
+                level_len
+            };
+
             let mut level = Vec::with_capacity(level_len as _);
-            self.data.by_ref().take(level_len as _).read_to_end(&mut level).ok()?;
+            self.data
+                .by_ref()
+                .take(level_len as _)
+                .read_to_end(&mut level)
+                .ok()?;
+
             Some(level)
         }
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -15,7 +15,7 @@ use core::{fmt, ops::Deref};
 /// ```
 #[derive(Clone, Copy)]
 pub struct Ktx<D> {
-    header: KtxHeader,
+    pub header: KtxHeader,
     ktx_data: D,
     texture_start: u32,
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -11,7 +11,7 @@ use core::{fmt, ops::Deref};
 /// ```
 /// # use ktx::*;
 /// let image: Ktx<_> = include_ktx!("../tests/babg-bc3.ktx");
-/// let texture_levels: Vec<&[u8]> = image.textures().collect();
+/// let texture_levels = image.textures().collect::<Vec<_>>();
 /// ```
 #[derive(Clone, Copy)]
 pub struct Ktx<D> {
@@ -29,7 +29,9 @@ impl<D> AsRef<KtxHeader> for Ktx<D> {
 
 impl<D> fmt::Debug for Ktx<D> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Ktx").field("header", &self.header).finish()
+        fmt.debug_struct("Ktx")
+            .field("header", &self.header)
+            .finish()
     }
 }
 
@@ -42,7 +44,11 @@ where
     pub fn new(ktx_data: D) -> Self {
         let header = KtxHeader::new(&ktx_data);
         let texture_start = 64 + header.bytes_of_key_value_data();
-        Self { header, ktx_data, texture_start }
+        Self {
+            header,
+            ktx_data,
+            texture_start,
+        }
     }
 
     /// Returns texture data at the input level, starting at `0`.
@@ -51,14 +57,18 @@ where
     ///
     /// Input level is >= the `mipmap_levels` value.
     #[inline]
-    pub fn texture_level(&self, level: u32) -> &[u8] {
+    pub fn texture_level(&self, level: u32) -> Texture<'_> {
         self.textures().nth(level as _).expect("invalid level")
     }
 
     /// Returns an iterator over the texture levels starting at level 0.
     #[inline]
     pub fn textures(&self) -> Textures<'_, D> {
-        Textures { parent: self, next_level: 0, level_end: self.texture_start as _ }
+        Textures {
+            parent: self,
+            next_level: 0,
+            level_end: self.texture_start as _,
+        }
     }
 }
 
@@ -69,6 +79,31 @@ where
     #[inline]
     fn from(d: D) -> Self {
         Ktx::new(d)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Texture<'a> {
+    TwoDim(&'a [u8]),
+    Cubemap {
+        all: &'a [u8],
+        x: &'a [u8],
+        x_neg: &'a [u8],
+        y: &'a [u8],
+        y_neg: &'a [u8],
+        z: &'a [u8],
+        z_neg: &'a [u8],
+    },
+}
+
+impl<'a> std::ops::Deref for Texture<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match *self {
+            Self::TwoDim(slice) => slice,
+            Self::Cubemap { all, .. } => all,
+        }
     }
 }
 
@@ -84,7 +119,7 @@ impl<'a, D> Iterator for Textures<'a, D>
 where
     D: Deref<Target = [u8]>,
 {
-    type Item = &'a [u8];
+    type Item = Texture<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.next_level >= self.parent.mipmap_levels() {
@@ -93,13 +128,37 @@ where
             self.next_level += 1;
 
             let l_end = self.level_end;
-            let next_lvl_len = if self.parent.big_endian() {
+            let next_tex_len = if self.parent.big_endian() {
                 BigEndian::read_u32(&self.parent.ktx_data[l_end..l_end + 4])
             } else {
                 LittleEndian::read_u32(&self.parent.ktx_data[l_end..l_end + 4])
             };
-            self.level_end = l_end + 4 + next_lvl_len as usize;
-            Some(&self.parent.ktx_data[l_end + 4..self.level_end])
+
+            if self.parent.array_elements() == 0 && self.parent.faces() == 6 {
+                self.level_end = l_end + 4 + (6 * next_tex_len as usize);
+
+                let level_begin = l_end + 4;
+                let next_tex_len = next_tex_len as usize;
+                Some(Texture::Cubemap {
+                    all: &self.parent.ktx_data[level_begin..self.level_end],
+                    x: &self.parent.ktx_data[level_begin..(level_begin + next_tex_len)],
+                    x_neg: &self.parent.ktx_data
+                        [level_begin + next_tex_len..(level_begin + (next_tex_len * 2))],
+                    y: &self.parent.ktx_data
+                        [level_begin + (next_tex_len * 2)..(level_begin + (next_tex_len * 3))],
+                    y_neg: &self.parent.ktx_data
+                        [level_begin + (next_tex_len * 3)..(level_begin + (next_tex_len * 4))],
+                    z: &self.parent.ktx_data
+                        [level_begin + (next_tex_len * 4)..(level_begin + (next_tex_len * 5))],
+                    z_neg: &self.parent.ktx_data
+                        [level_begin + (next_tex_len * 5)..(level_begin + (next_tex_len * 6))],
+                })
+            } else {
+                self.level_end = l_end + 4 + next_tex_len as usize;
+                Some(Texture::TwoDim(
+                    &self.parent.ktx_data[l_end + 4..self.level_end],
+                ))
+            }
         }
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,67 @@
+use crate::header::{KtxHeader, KtxInfo, KTX_IDENTIFIER};
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
+
+pub struct KtxBuilder {
+    header: KtxHeader,
+    levels: Vec<Vec<u8>>,
+}
+impl KtxBuilder {
+    pub fn new(header: KtxHeader) -> Self {
+        Self {
+            header,
+            levels: Vec::default(),
+        }
+    }
+
+    pub fn with_level(mut self, texture: Vec<u8>) -> Self {
+        self.add_level(texture);
+
+        self
+    }
+
+    pub fn add_level(&mut self, texture: Vec<u8>) {
+        self.levels.push(texture);
+    }
+
+    pub fn to_vec(self) -> Result<Vec<u8>, &'static str> {
+        let KtxBuilder { header, levels } = self;
+
+        // allocate the full size
+        let size = KTX_IDENTIFIER.len()
+            + std::mem::size_of::<KtxHeader>()
+            + levels
+                .iter()
+                .map(|level| level.len() + std::mem::size_of::<u32>())
+                .sum::<usize>();
+
+        let mut buffer = Vec::with_capacity(size);
+        buffer.resize(size, 0);
+
+        header.write(&mut buffer[0..64]);
+
+        let mut cur_index = 64;
+
+        for level in levels {
+            let write_end = level.len() as u32 / header.faces();
+            let cur_end = cur_index + level.len() + std::mem::size_of::<u32>();
+
+            if header.big_endian() {
+                BigEndian::write_u32_into(
+                    &[write_end],
+                    &mut buffer[cur_index..cur_index + std::mem::size_of::<u32>()],
+                );
+            } else {
+                LittleEndian::write_u32_into(
+                    &[write_end],
+                    &mut buffer[cur_index..cur_index + std::mem::size_of::<u32>()],
+                )
+            }
+
+            buffer[cur_index + std::mem::size_of::<u32>()..cur_end].copy_from_slice(&level);
+
+            cur_index = cur_end;
+        }
+
+        Ok(buffer)
+    }
+}

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -11,7 +11,11 @@ fn include_logo_example() {
     assert_eq!(ktx.gl_type_size(), 1, "gl_type_size");
     assert_eq!(ktx.gl_format(), 0, "gl_format");
     assert_eq!(ktx.gl_internal_format(), 33779, "gl_internal_format");
-    assert_eq!(ktx.gl_base_internal_format(), 6408, "gl_base_internal_format");
+    assert_eq!(
+        ktx.gl_base_internal_format(),
+        6408,
+        "gl_base_internal_format"
+    );
     assert_eq!(ktx.pixel_width(), 260, "pixel_width");
     assert_eq!(ktx.pixel_height(), 200, "pixel_height");
     assert_eq!(ktx.pixel_depth(), 0, "pixel_depth");
@@ -30,7 +34,11 @@ fn read_logo_example() -> io::Result<()> {
     assert_eq!(ktx.gl_type_size(), 1, "gl_type_size");
     assert_eq!(ktx.gl_format(), 0, "gl_format");
     assert_eq!(ktx.gl_internal_format(), 33779, "gl_internal_format");
-    assert_eq!(ktx.gl_base_internal_format(), 6408, "gl_base_internal_format");
+    assert_eq!(
+        ktx.gl_base_internal_format(),
+        6408,
+        "gl_base_internal_format"
+    );
     assert_eq!(ktx.pixel_width(), 260, "pixel_width");
     assert_eq!(ktx.pixel_height(), 200, "pixel_height");
     assert_eq!(ktx.pixel_depth(), 0, "pixel_depth");
@@ -64,14 +72,38 @@ fn include_logo_example_textures() {
     let ktx = include_ktx!("babg-bc3.ktx");
     let mut textures = ktx.textures();
 
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_0_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_1_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_2_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_3_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_4_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_5_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_6_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_7_BLAKE);
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_0_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_1_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_2_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_3_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_4_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_5_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_6_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_7_BLAKE
+    );
     assert_eq!(textures.next(), None);
 }
 
@@ -80,14 +112,38 @@ fn read_logo_example_textures() -> io::Result<()> {
     let ktx = ktx::Decoder::new(io::BufReader::new(fs::File::open("tests/babg-bc3.ktx")?))?;
     let mut textures = ktx.read_textures();
 
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_0_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_1_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_2_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_3_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_4_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_5_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_6_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&textures.next().unwrap())), LOGO_LEVEL_7_BLAKE);
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_0_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_1_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_2_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_3_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_4_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_5_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_6_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&textures.next().unwrap())),
+        LOGO_LEVEL_7_BLAKE
+    );
     assert_eq!(textures.next(), None);
     Ok(())
 }
@@ -96,8 +152,14 @@ fn read_logo_example_textures() -> io::Result<()> {
 fn logo_example_texture_level() {
     let ktx = include_ktx!("babg-bc3.ktx");
 
-    assert_eq!(format!("{:x}", Blake2s::digest(&ktx.texture_level(0))), LOGO_LEVEL_0_BLAKE);
-    assert_eq!(format!("{:x}", Blake2s::digest(&ktx.texture_level(4))), LOGO_LEVEL_4_BLAKE);
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&ktx.texture_level(0))),
+        LOGO_LEVEL_0_BLAKE
+    );
+    assert_eq!(
+        format!("{:x}", Blake2s::digest(&ktx.texture_level(4))),
+        LOGO_LEVEL_4_BLAKE
+    );
 }
 
 #[test]
@@ -107,4 +169,93 @@ fn logo_example_debug() {
         &dbg_string,
         "Ktx { header: KtxHeader { big_endian: false, gl_type: 0, gl_type_size: 1, gl_format: 0, gl_internal_format: 33779, gl_base_internal_format: 6408, pixel_width: 260, pixel_height: 200, pixel_depth: 0, array_elements: 0, faces: 1, mipmap_levels: 8, bytes_of_key_value_data: 0 } }"
     );
+}
+
+#[test]
+fn papermill_cubemap_header() -> io::Result<()> {
+    let ktx = include_ktx!("papermill.ktx");
+
+    assert!(!ktx.big_endian(), "!big_endian");
+    assert_eq!(ktx.gl_type(), 5131, "gl_type");
+    assert_eq!(ktx.gl_type_size(), 2, "gl_type_size");
+    assert_eq!(ktx.gl_format(), 6408, "gl_format");
+    assert_eq!(ktx.gl_internal_format(), 34842, "gl_internal_format");
+    assert_eq!(
+        ktx.gl_base_internal_format(),
+        6408,
+        "gl_base_internal_format"
+    );
+    assert_eq!(ktx.pixel_width(), 512, "pixel_width");
+    assert_eq!(ktx.pixel_height(), 512, "pixel_height");
+    assert_eq!(ktx.pixel_depth(), 0, "pixel_depth");
+    assert_eq!(ktx.array_elements(), 0, "array_elements");
+    assert_eq!(ktx.faces(), 6, "faces");
+    assert_eq!(ktx.mipmap_levels(), 10, "mipmap_levels");
+    assert_eq!(ktx.bytes_of_key_value_data(), 0, "bytes_of_key_value_data");
+
+    Ok(())
+}
+
+#[test]
+fn papermill_cubemap_textures() -> io::Result<()> {
+    let ktx = include_ktx!("papermill.ktx");
+
+    let _ = ktx.texture_level(9);
+    let textures = ktx.textures().collect::<Vec<_>>();
+    assert_eq!(textures.len(), 10);
+
+    for texture in &textures {
+        match texture {
+            crate::slice::Texture::Cubemap { .. } => {}
+            _ => panic!("Test should be a cubemap with 10 mip levels!"),
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn logo_roundtrip() {
+    use crate::{header::KtxHeader, write::KtxBuilder};
+    let ktx = include_ktx!("babg-bc3.ktx");
+
+    let mut builder = KtxBuilder::new(ktx.as_ref().clone());
+    ktx.textures()
+        .for_each(|tex| builder.add_level(tex.to_vec()));
+
+    let buffer = builder.to_vec().unwrap();
+    let read = Ktx::new(buffer.as_slice());
+
+    let orig_header: &KtxHeader = ktx.as_ref();
+    let read_header: &KtxHeader = read.as_ref();
+    assert_eq!(orig_header, read_header);
+
+    ktx.textures()
+        .zip(read.textures())
+        .for_each(|(left, right)| {
+            assert_eq!(left, right);
+        });
+}
+
+#[test]
+fn papermill_roundtrip() {
+    use crate::{header::KtxHeader, write::KtxBuilder};
+    let ktx = include_ktx!("papermill.ktx");
+
+    let mut builder = KtxBuilder::new(ktx.as_ref().clone());
+    ktx.textures()
+        .for_each(|tex| builder.add_level(tex.to_vec()));
+
+    let buffer = builder.to_vec().unwrap();
+    let read = Ktx::new(buffer.as_slice());
+
+    let orig_header: &KtxHeader = ktx.as_ref();
+    let read_header: &KtxHeader = read.as_ref();
+    assert_eq!(orig_header, read_header);
+
+    ktx.textures()
+        .zip(read.textures())
+        .for_each(|(left, right)| {
+            assert_eq!(left, right);
+        });
 }

--- a/tests/example.rs
+++ b/tests/example.rs
@@ -240,8 +240,10 @@ fn logo_roundtrip() {
 #[test]
 fn papermill_roundtrip() {
     use crate::{header::KtxHeader, write::KtxBuilder};
-    let ktx = include_ktx!("papermill.ktx");
+    use std::io::Write;
 
+    let ktx = include_ktx!("papermill.ktx");
+    println!("ktx = {:?}", ktx);
     let mut builder = KtxBuilder::new(ktx.as_ref().clone());
     ktx.textures()
         .for_each(|tex| builder.add_level(tex.to_vec()));
@@ -258,4 +260,7 @@ fn papermill_roundtrip() {
         .for_each(|(left, right)| {
             assert_eq!(left, right);
         });
+
+    let mut test = std::fs::File::create("target/test.ktx").unwrap();
+    test.write_all(&buffer).unwrap();
 }


### PR DESCRIPTION
- Fix reading cubemaps, as it was currently unsupported.
- Closes #3 as it was not an appropriate fix for that

I do not believe this still actually properly reads texture
arrays/multi-face textures, but this does handle the common cases of
"standard" textures (which you already implemented) and adds appropriate
support for 6-face textures (cubemaps) for reading and writing.

This PR added an API change to the `texture` iterator for slice, so I
have incremented the version to 0.4 as it is a breaking API change.