### PR TITLE
Make KTX struct have public properties

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -15,9 +15,9 @@ use core::{fmt, ops::Deref};
 /// ```
 #[derive(Clone, Copy)]
 pub struct Ktx<D> {
-    header: KtxHeader,
-    ktx_data: D,
-    texture_start: u32,
+    pub header: KtxHeader,
+    pub ktx_data: D,
+    pub texture_start: u32,
 }
 
 impl<D> AsRef<KtxHeader> for Ktx<D> {


### PR DESCRIPTION
It is possible to create a slice using a Vec<u8> of data instead of a BufReader, and this outputs the ktxdata, headers, and start location of the textures. From this, I can do some texture manipulation. But I cannot access these fields from another application because they are private. I propose making them public to fix this.